### PR TITLE
doc: update SetTextConten edit

### DIFF
--- a/API.md
+++ b/API.md
@@ -150,7 +150,7 @@ export type SetAttributes = {
 ```typescript
 export type SetTextContent = {
   element: Element;
-  textContent: string | null;
+  textContent: string;
 };
 ```
 


### PR DESCRIPTION
I have started to implement the new API and have seen that `textContent` only returns `null` for node of type document or doctype we should restrict the key `textContent` to `string`. To return any text content from any element `textContent` is set to `""`.