### PR TITLE
doc: remove editCount introduce docChangeCounter

### DIFF
--- a/API.md
+++ b/API.md
@@ -76,7 +76,7 @@ History of edits done to `doc`.
 
 ### `docChangeCounter`
 
-Keeps count of changes to the `doc`, including undo and redo, and indicates a changed `doc`. 
+Keeps track of changes to the `doc`, including undo and redo, and indicates a changed `doc`. 
 
 ### `plugins`
 

--- a/API.md
+++ b/API.md
@@ -76,7 +76,7 @@ History of edits done to `doc`.
 
 ### `docVersion`
 
-Keeps track of changes to the `doc`, including undo and redo, and indicates a changed `doc`. 
+A change in the property indicates a change to the `doc` as a result of edits (including undo and redo). 
 
 ### `plugins`
 

--- a/API.md
+++ b/API.md
@@ -74,7 +74,7 @@ Filename extensions of user-editable documents.
 ### `history`
 History of edits done to `doc`.
 
-### `docChangeCounter`
+### `docVersion`
 
 Keeps track of changes to the `doc`, including undo and redo, and indicates a changed `doc`. 
 

--- a/API.md
+++ b/API.md
@@ -74,9 +74,9 @@ Filename extensions of user-editable documents.
 ### `history`
 History of edits done to `doc`.
 
-### `editCount`
+### `docChangeCounter`
 
-Index of the current log entry in the `history`. Is incremented with every new edit and updated on undo/redo. 
+Keeps count of changes to the `doc`, including undo and redo, and indicates a changed `doc`. 
 
 ### `plugins`
 


### PR DESCRIPTION
With the introduction of the `squash` key in the edit event `editCounter` as defined atm is not a good indicator anymore. I therefore propose a new property. I also propose to remove to not forward `editCount` to plugins as we give the `history` from which `editCount` can easily be derived from.