### PR TITLE
doc: Extend edit event options with createHistoryEntry flag

### DIFF
--- a/API.md
+++ b/API.md
@@ -99,6 +99,7 @@ export type EditDetailV2<E extends Edit = Edit> = {
   edit: E;
   title?: string;
   squash?: boolean;
+  createHistoryEntry?: boolean;
 }
 
 export type EditEventV2<E extends Edit = Edit> = CustomEvent<EditDetailV2<E>>;
@@ -106,6 +107,7 @@ export type EditEventV2<E extends Edit = Edit> = CustomEvent<EditDetailV2<E>>;
 export type EditEventOptions = {
   title?: string;
   squash?: boolean;
+  createHistoryEntry?: boolean;
 }
 
 export function newEditEventV2<E extends Edit>(edit: E, options: EditEventOptions): EditEventV2<E> {
@@ -126,6 +128,8 @@ declare global {
 Its `title` property is a human-readable description of the edit for displaying in the editing history dialog.
 
 The `squash` flag indicates whether the edit should be merged with the previous edit in the history.
+
+The `createHistoryEntry` flag decides if a history entry should be created. Defaults to `true`. 
 
 #### `Edit` type
 


### PR DESCRIPTION
### Feature
As a developer I want to be able to decide if an edit event creates a history entry or not. The flag `createHistoryEntry` defaults to `true`, because in most cases we want to create history entries.

### Use case
In the open-scd distribution the `Editor` and `History` are separate addons and when `redo`, `undo` are triggered from the `History` addon it in turn dispatches edit events. When those edit events are consumed in the `Editor` addon we do not want to create any history entries.

**History.ts**
```ts
undo() {
  // ...
  const undoEdit = historyEntry.undo;
  this.host.dispatch(newEditEvent(undoEdit, { createHistoryEntry: false }));
}
```

