### PR TITLE
fix: refresh on opening of the same document name

### DIFF
--- a/open-scd.editing.spec.ts
+++ b/open-scd.editing.spec.ts
@@ -206,6 +206,22 @@ describe('Editing Element', () => {
     expect(editor.docName).to.equal('test.scd');
   });
 
+  it('refreshes a document with the same name as one already opened on OpenDocEvent', async () => {
+    editor.dispatchEvent(newOpenEvent(sclDoc, 'test.scd'));
+    const firstUpdate = editor.updateComplete;
+    await firstUpdate;
+    sclDoc = new DOMParser().parseFromString(
+      util.sclDocString,
+      'application/xml'
+    );
+    editor.dispatchEvent(newOpenEvent(sclDoc, 'test.scd'));
+    const secondUpdate = editor.updateComplete;
+    await secondUpdate;
+    expect(firstUpdate).to.not.equal(secondUpdate);
+    expect(editor.doc).to.equal(sclDoc);
+    expect(editor.docName).to.equal('test.scd');
+  });
+
   it('inserts an element on Insert', () => {
     const parent = sclDoc.documentElement;
     const node = sclDoc.createElement('test');

--- a/open-scd.ts
+++ b/open-scd.ts
@@ -207,6 +207,7 @@ export class OpenSCD extends LitElement {
   handleOpenDoc({ detail: { docName, doc } }: OpenEvent) {
     this.docName = docName;
     this.docs[this.docName] = doc;
+    this.requestUpdate();
   }
 
   updateVersion(): void {


### PR DESCRIPTION
Closes openscd/open-scd-core#92

Avoids the drive by modifications to testing approach of #23 