### PR TITLE
docs(API): bring type declaration in line with description

### DIFF
--- a/API.md
+++ b/API.md
@@ -36,7 +36,7 @@ export default class MyPlugin extends HTMLElement {
     'ssd',
   ];
   history: LogEntry[];
-  editCount: number = 0;
+  docVersion: unknown;
   plugins: { menu: Plugin[], editor: Plugin[] }[];
   locale: string = 'en';
 }


### PR DESCRIPTION
Updates the API.md file to change `editCount` to `docVersion` in accordance with the prose description.